### PR TITLE
Fixed bug with RosBE-rc overriding path.

### DIFF
--- a/RosBE-Unix/Base-i386/scripts/RosBE-rc
+++ b/RosBE-Unix/Base-i386/scripts/RosBE-rc
@@ -1,6 +1,9 @@
 # extend user's RC file
+
 if [ -f $HOME/.bashrc ]; then
+  SAVEDPATH=$PATH
   source $HOME/.bashrc
+  PATH=$SAVEDPATH
 fi
 
 # identify us in prompt


### PR DESCRIPTION
Preserved path from being overridden while reading user's bashrc by putting current path in a variable SAVEDPATH and the restoring that onto PATH after sourcing bashrc.